### PR TITLE
Add manufacturer ID 773 to Z-Push Button 2 driver

### DIFF
--- a/drivers/Z-push-button-2/driver.compose.json
+++ b/drivers/Z-push-button-2/driver.compose.json
@@ -16,7 +16,7 @@
 		"batteries": ["CR2450"]
 	},
 	"zwave": {
-		"manufacturerId": [411, 816],
+		"manufacturerId": [411, 816, 773],
 		"productTypeId": 768,
 		"productId": 41735,
 		"security": ["none"],


### PR DESCRIPTION
## Problem

Some Z-Push Button 2 units report manufacturer ID 773 instead of 
the expected Heatit ID. This causes the device to be added as a 
generic "Unknown Z-Wave Device" and prevents the Heatit Controls 
app from recognizing it during inclusion.

## Affected hardware

Tested with two Z-Push Button 2 units:
- Model: Heatit Z-Push Button 2 White (El-nr. 45 125 80)
- Hardware revision: 201006V1
- Manufacturer ID reported: 773
- Product Type ID: 768
- Product ID: 41735
- Firmware: 1.28

## Background

The same issue was reported and fixed for Z-Push Button 8 in #54 
(closed June 2021), but the fix was not applied to Z-Push Button 2.

Multiple users have reported the same problem on the Homey Community 
Forum:
https://community.homey.app/t/app-pro-heatit-controls-app-v4-2-6/49914/103

## Fix

Added 773 to the manufacturerId list in 
`drivers/Z-push-button-2/driver.compose.json`.

## Testing

- Both affected units now include correctly via Heatit Controls app
- Existing Z-Push Button 4 device (manufacturer ID 411) continues 
  to work without changes
- Scene flows work as expected for single press, double press, 
  triple press, and hold on both buttons